### PR TITLE
Fixed bug in force dependent velocity

### DIFF
--- a/simcore/simulation/library/anchor.cpp
+++ b/simcore/simulation/library/anchor.cpp
@@ -224,7 +224,7 @@ void Anchor::Diffuse() {
     double force_proj = dot_product(n_dim_, force_, orientation_);
     // Add force-velocity relationship to diffusion
     if (SIGNOF(force_proj) != SIGNOF(vel)) {
-      double fdep = 1 - force_proj / f_stall_;
+      double fdep = 1 - ABS(force_proj) / f_stall_;
       // TODO Check whether the force can cause the motor to reverse
       // For now, assume that diffusion can be biased in either direction
       // if (fdep > 1) {


### PR DESCRIPTION
## Description of changes
Fixed a bug wherein the projected force on an anchor was contributing to a plus-ended drift behavior due to not using the magnitude of the force in the force dependent velocity calculation.

## Changes in behavior
Force dependent velocity and crosslinker diffusion should work together again properly. Force dependent velocity only opposes anchor stepping.

## Anything unresolved?
Tested for walking anchors, diffusing anchors, and both, each with and without force dependent velocity and everything seems to work fine.
