### PR TITLE
Jmm/zero cell fix

### DIFF
--- a/simcore/simulation/library/cell_list.cpp
+++ b/simcore/simulation/library/cell_list.cpp
@@ -33,14 +33,34 @@ void CellList::Init(int n_dim, int n_periodic, double system_radius) {
     }
   }
 #endif
+  if (_n_cells_1d_ < 0) {
+    /* Give debugging details if we have bad parameters and throw error. Note
+       that _n_cells_1d_ can be 0 if the interaction distance is greater than
+       the system diameter */
+    Logger::Debug("n_cells_1d: %d, min_cell_length: %2.6f, system_radius:"
+                  " %2.2f",
+                  _n_cells_1d_, _min_cell_length_, system_radius);
+    Logger::Error("Cell list received bad initialization parameters!");
+  } else if (_n_dim_ == _n_periodic_ && _n_cells_1d_ <= 3) {
+    /* Warn users that we will be effectively doing all-pair interactions. If we
+       have periodic BCs, 3 cells per side will result in all pairs */
+    Logger::Warning("Cell list initialized with 3 cells or fewer. Calculating"
+                    " all-pair interactions");
+    // Fewer than three cells will have equivalent behavior
+    _n_cells_1d_ = 3;
+  } else if (_n_cells_1d_ <= 2) {
+    /* If we do not have periodic BCs, this warning should only apply when we
+       have 2 cells per side*/
+    Logger::Warning("Cell list initialized with 2 cells or fewer. Calculating"
+                    " all-pair interactions");
+    // Fewer than 2 cells will have equivalent behavior
+    _n_cells_1d_ = 2;
+  }
   _cell_length_ = (double)2 * system_radius / _n_cells_1d_;
   _n_dim_ = n_dim;
   _n_periodic_ = n_periodic;
   Logger::Debug("Cell list initialized with %d cells per side of length %2.2f",
                 _n_cells_1d_, _cell_length_);
-  if (_n_cells_1d_ < 1 || _cell_length_ < 0) {
-    Logger::Error("Cell list received bad initialization parameters!");
-  }
 }
 
 void CellList::BuildCellList() {

--- a/simcore/simulation/library/simulation.cpp
+++ b/simcore/simulation/library/simulation.cpp
@@ -82,7 +82,7 @@ void Simulation::PrintComplete() {
 /* Update the positions of all objects in the system using numerical
  * integration for one time step defined by the delta parameter. */
 void Simulation::Integrate() {
-  Logger::Debug("Updating object positions");
+  Logger::Trace("Updating object positions");
   for (auto it = species_.begin(); it != species_.end(); ++it) {
     (*it)->UpdatePositions();
   }
@@ -90,7 +90,7 @@ void Simulation::Integrate() {
 
 /* Calculate interaction forces between all objects if necessary. */
 void Simulation::Interact() {
-  Logger::Debug("Calculating object interactions");
+  Logger::Trace("Calculating object interactions");
   ix_mgr_.Interact();
 }
 


### PR DESCRIPTION
## Description of changes
Allow cell list to initialize properly if the number of initial cells is zero due to long range interactions. This can occur due to the calculation of number of cells being
`n_cells_1d = floor(system_diameter/interaction_distance)`

## Changes in behavior
* Having very long range interactions will no longer have CellList throw an error for having bad parameters. Instead, CellList will initialize with parameters for all-pairs interactions.
* Logging information for updating object positions and calculating object interactions changed from Debug to Trace. This makes Debug logs more readable.

## Anything unresolved?
Travis does not complain.