### PR TITLE
Added optionality to use binding volume of unbound anchor in S->U

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -301,6 +301,10 @@ crosslink:                          # Parameters specific to crosslinks.
                                     # Units in #/area or #/vol in 2D or 3D for free xlinks. In
                                     # #/area for grid spacing. In #/length or #/area for 2D or 3D
                                     # boundaries.
+  use_binding_volume: [true, bool]  # Calculate concentration of unbound head of 
+                                    # singly bound protein by finding a binding 
+                                    # volume in which it is statistically likely
+                                    # to exist.
   infinite_reservoir_flag: [false, bool] # Do crosslinks bind from an infinite
                                          # reservoir when going from unbound to
                                          # singly bound.  Only applicable for

--- a/simcore/simulation/library/crosslink.cpp
+++ b/simcore/simulation/library/crosslink.cpp
@@ -22,7 +22,8 @@ void Crosslink::Init(crosslink_parameters *sparams) {
                                      // anisotropic_spring_flag is true
   anisotropic_spring_flag_ = sparams_->anisotropic_spring_flag;
   if (anisotropic_spring_flag_) {
-    Logger::Warning("anistropic_spring_flag is not currently implemented for"
+    Logger::Warning(
+        "anistropic_spring_flag is not currently implemented for"
         " crosslinkers");
   }
   static_flag_ = sparams_->static_flag;
@@ -86,9 +87,8 @@ void Crosslink::SinglyKMC() {
     if (!static_flag_ && polar_affinity_ < 1) {
       anchors_[0].CalculatePolarAffinity(kmc_bind_factor);
     }
-    kmc_bind.CalcTotProbsSD(anchors_[0].GetNeighborListMem(), kmc_filter,
-                            anchors_[0].GetBoundOID(), 0, k_spring_, 1.0,
-                            rest_length_, kmc_bind_factor);
+    kmc_bind.LUCalcTotProbsSD(anchors_[0].GetNeighborListMem(), kmc_filter,
+                              anchors_[0].GetBoundOID(), kmc_bind_factor);
     kmc_bind_prob = kmc_bind.getTotProb();
   }
   // Find out whether we bind, unbind, or neither.
@@ -140,8 +140,8 @@ void Crosslink::DoublyKMC() {
   double fdep;
   // TODO: anisotropic springs in tethers
   // For anisotropic springs apply second spring constant for compression
-  //if (anisotropic_spring_flag_ && tether_stretch < 0) {
-    //fdep = fdep_factor_ * 0.5 * k2_spring_ * SQR(tether_stretch);
+  // if (anisotropic_spring_flag_ && tether_stretch < 0) {
+  // fdep = fdep_factor_ * 0.5 * k2_spring_ * SQR(tether_stretch);
   //} else {
   fdep = fdep_factor_ * 0.5 * k_spring_ * SQR(tether_stretch);
   //}

--- a/simcore/simulation/library/crosslink_species.cpp
+++ b/simcore/simulation/library/crosslink_species.cpp
@@ -27,8 +27,7 @@ void CrosslinkSpecies::InitInteractionEnvironment(std::vector<Object *> *objs,
   update_ = update;
   /* TODO Lookup table only works for filament objects. Generalize? */
   lut_.Init(sparams_.k_spring * .5, sparams_.rest_length, 1);
-  // printf("sparams_.rest_length = %f\n", sparams_.rest_length);
-  // printf("max_force = %f\n", sparams_.k_spring * lut_.getLUCutoff());
+  if (sparams_.use_binding_volume) lut_.calcBindVol();
 }
 
 void CrosslinkSpecies::InsertCrosslinks() {

--- a/simcore/simulation/library/default_params.hpp
+++ b/simcore/simulation/library/default_params.hpp
@@ -57,7 +57,6 @@
   default_config["filament"]["flagella_amplitude"] = "1";
   default_config["filament"]["flocking_analysis"] = "false";
   default_config["filament"]["polydispersity_flag"] = "false";
-  default_config["filament"]["polydispersity_warn_on_truncate"] = "0";
   default_config["filament"]["custom_set_tail"] = "false";
   default_config["br_bead"]["driving_factor"] = "0";
   default_config["br_bead"]["packing_fraction"] = "-1";
@@ -72,6 +71,7 @@
   default_config["spindle"]["spring_length"] = "0";
   default_config["spindle"]["spb_diameter"] = "5";
   default_config["crosslink"]["concentration"] = "0";
+  default_config["crosslink"]["use_binding_volume"] = "true";
   default_config["crosslink"]["infinite_reservoir_flag"] = "false";
   default_config["crosslink"]["bind_site_density"] = "1";
   default_config["crosslink"]["walker_flag"] = "false";

--- a/simcore/simulation/library/parameters.hpp
+++ b/simcore/simulation/library/parameters.hpp
@@ -78,7 +78,6 @@ struct species_parameters<species_id::filament>
   double flagella_amplitude = 1;
   bool flocking_analysis = false;
   bool polydispersity_flag = false;
-  int polydispersity_warn_on_truncate = 0;
   bool custom_set_tail = false;
 };
 typedef species_parameters<species_id::filament> filament_parameters;
@@ -117,6 +116,7 @@ template <>
 struct species_parameters<species_id::crosslink>
     : public species_base_parameters {
   double concentration = 0;
+  bool use_binding_volume = true;
   bool infinite_reservoir_flag = false;
   double bind_site_density = 1;
   bool walker_flag = false;

--- a/simcore/simulation/library/parse_params.hpp
+++ b/simcore/simulation/library/parse_params.hpp
@@ -381,8 +381,6 @@ species_base_parameters *parse_species_params(std::string sid,
       params.flocking_analysis = jt->second.as<bool>();
       } else if (param_name.compare("polydispersity_flag")==0) {
       params.polydispersity_flag = jt->second.as<bool>();
-      } else if (param_name.compare("polydispersity_warn_on_truncate")==0) {
-      params.polydispersity_warn_on_truncate = jt->second.as<int>();
       } else if (param_name.compare("custom_set_tail")==0) {
       params.custom_set_tail = jt->second.as<bool>();
       } else {
@@ -559,6 +557,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.n_spec = jt->second.as<int>();
       } else if (param_name.compare("concentration")==0) {
       params.concentration = jt->second.as<double>();
+      } else if (param_name.compare("use_binding_volume")==0) {
+      params.use_binding_volume = jt->second.as<bool>();
       } else if (param_name.compare("infinite_reservoir_flag")==0) {
       params.infinite_reservoir_flag = jt->second.as<bool>();
       } else if (param_name.compare("bind_site_density")==0) {


### PR DESCRIPTION
binding probability.

## Description of changes
Added flag to crosslink parameters called use_binding_volume which will divide k_on_d by statistically available binding volume to get proper units for on rate. Default is "true".

## Changes in behavior
If use_binding_volume is set to false, k_on_d will be divided by one instead of the calculated binding volume. This is useful when you want to maintain the quotient k_on_d/k_off_d scanning over different values of crosslinker spring constants or rest lengths.

## Anything unresolved?
There is also the option now in KMC to set this volume in some other way. However, there is no use for this in simcore at the moment.
