### PR TITLE
Fixed bug in anchors where error was thrown unnecessarily

### DIFF
--- a/simcore/simulation/library/anchor.cpp
+++ b/simcore/simulation/library/anchor.cpp
@@ -459,8 +459,8 @@ const double Anchor::GetMaxVelocity() const {
       return max_velocity_d_;
       break;
     case +bind_state::unbound:
-      Logger::Error(
-          "Crosslinker is unbound. Anchors cannot walk if not attached.");
+      // Logger::Error(
+      //    "Crosslinker is unbound. Anchors cannot walk if not attached.");
       return 0;
       break;
     default:
@@ -478,9 +478,9 @@ const double Anchor::GetDiffusionConst() const {
       return diffusion_d_;
       break;
     case +bind_state::unbound:
-      Logger::Error(
-          "Crosslinker is unbound. Anchors cannot diffuse on objects if not "
-          "attached.");
+      // Logger::Error(
+      //    "Crosslinker is unbound. Anchors cannot diffuse on objects if not "
+      //    "attached.");
       return 0;
       break;
     default:
@@ -498,9 +498,9 @@ const double Anchor::GetKickAmplitude() const {
       return kick_amp_d_;
       break;
     case +bind_state::unbound:
-      Logger::Error(
-          "Crosslinker is unbound. Anchors cannot diffuse on objects if not "
-          "attached.");
+      // Logger::Error(
+      //    "Crosslinker is unbound. Anchors cannot diffuse on objects if not "
+      //    "attached.");
       return 0;
       break;
     default:


### PR DESCRIPTION

## Description of changes
Got rid of error thrown when looking up diffusion constants, walking velocity, and kick amplitudes.

## Changes in behavior
Simulations will not end when unbound motors try to update position. Instead, update position will just return like in previous versions of code.

## Anything unresolved?
nah uh
