### PR TITLE
Update configurator to use new directory tree structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ build*
 201*
 !CMake*
 *__pycache__*
+version_generator.cpp

--- a/src/configurator/configurator.cpp
+++ b/src/configurator/configurator.cpp
@@ -3,6 +3,8 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <vector>
 #include <yaml-cpp/yaml.h>
 
@@ -41,11 +43,9 @@ private:
 
 public:
   Configurator(std::string default_config_file)
-      : parse_params_("simcore/simulation/library/parse_params.hpp",
-                      std::ios_base::out),
-        parameters_("simcore/simulation/library/parameters.hpp",
-                    std::ios_base::out),
-        default_config_("simcore/simulation/library/default_params.hpp",
+      : parse_params_("include/simcore/parse_params.hpp", std::ios_base::out),
+        parameters_("include/simcore/parameters.hpp", std::ios_base::out),
+        default_config_("include/simcore/default_params.hpp",
                         std::ios_base::out) {
     node_ = YAML::LoadFile(default_config_file);
   }
@@ -53,9 +53,22 @@ public:
   void ConfigureSimcore();
 };
 
+struct stat info;
+
 int main(int argc, char *argv[]) {
   if (argc == 1) {
     return parse_error();
+  }
+
+  char pathname[] = "include/simcore";
+  if (stat(pathname, &info) != 0) {
+    printf("Cannot find %s: Are you in the project's root directory?\n", pathname);
+    exit(1);
+  } else if (info.st_mode & S_IFDIR) {
+    printf("Configuring simcore parameters\n");
+  } else {
+    printf("%s is not a directory.\n", pathname);
+    exit(1);
   }
   try {
     Configurator config(argv[1]);

--- a/src/version_generator.cpp
+++ b/src/version_generator.cpp
@@ -1,6 +1,0 @@
-#include "simcore/version_generator.hpp"
-/* This file should be configured by CMake to generate a cpp file that gets
-   compiled to make the simcore_version variable (the most recent git commit
-   sha1) available to any file that includes the above header */
-#define GIT_SHA1 "d5dd0b1dfa12be1343316b257c47c9c63075d8e2"
-const char simcore_version[] = GIT_SHA1;


### PR DESCRIPTION
## Description of changes
* Updated configurator.cpp to use new directory tree structure.
* Removed tracking of src/version_generator.cpp and added it to gitignore.

## Changes in behavior
* configurator.cpp looks for relative path `include/simcore` and will now complain if it is run from the wrong directory.
* version_generator.cpp should always be automatically generated by version_generator.cpp.in by CMake and we shouldn't have to track the new version_generator.cpp file with every new commit.

## Anything unresolved?
Don't think so.
