### PR TITLE
Added asymmetric spring potential to crosslinker model

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -336,12 +336,12 @@ crosslink:                          # Parameters specific to crosslinks.
   polar_affinity: [1, double]       # Ratio of (probability of binding for antiparallel)/(probability 
                                     # of binding parallel)  
   k_spring: [10, double]            # Spring constant of doubly-bound crosslinks.
-  k2_spring: [0, double]            # Spring constant for compression if asymmetric_spring_flag.
-  asymmetric_spring_flag: [false, bool] # Use k2_spring for compressive forces
-  f_stall: [100, double]            # Tether forces above f_stall cause bound crosslink heads to
-                                    # cease walking.
-  force_dep_vel_flag: [true, bool]  # Flag that causes walking crosslink heads to have force-
-                                    # dependent velocity.
+  k_spring_compress: [-1., double]  # Spring constant for compression. 
+                                    # If negative just use k_spring instead.
+  f_stall: [100, double]            # Tether forces above f_stall cause bound
+                                    # crosslink heads to cease walking.
+  force_dep_vel_flag: [true, bool]  # Flag that causes walking crosslink heads 
+                                    # to have force-dependent velocity.
   k_align: [0, double]              # Torsion spring constant for alignment of crosslink.
   rest_length: [0, double]          # Spring rest length of crosslink tether.
   step_direction: [0, int]          # Sets walker direction. If negative, walks toward filament

--- a/include/simcore/crosslink.hpp
+++ b/include/simcore/crosslink.hpp
@@ -2,10 +2,10 @@
 #define _SIMCORE_CROSSLINK_H_
 
 //#include "species.hpp"
-#include <KMC/kmc.hpp>
-#include <KMC/kmc_choose.hpp>
 #include "anchor.hpp"
 #include "minimum_distance.hpp"
+#include <KMC/kmc.hpp>
+#include <KMC/kmc_choose.hpp>
 
 // enum xstate { unbound, singly, doubly };
 
@@ -13,7 +13,7 @@
  * two objects in the simulation. Governs binding and unbinding of crosslink
  * heads, and tether forces between bound heads. */
 class Crosslink : public Object {
- private:
+private:
   crosslink_parameters *sparams_;
   draw_type draw_;
   bind_state state_;
@@ -22,7 +22,7 @@ class Crosslink : public Object {
   bool static_flag_ = false;
   bool asymmetric_spring_flag_ = false;
   double k_spring_;
-  double k2_spring_;
+  double k_spring_compress_;
   double k_align_;
   double rest_length_;
   double rcapture_;
@@ -40,7 +40,7 @@ class Crosslink : public Object {
   void UpdateAnchorPositions();
   void UpdateXlinkState();
 
- public:
+public:
   Crosslink(unsigned long seed);
   void Init(crosslink_parameters *sparams);
   void InitInteractionEnvironment(LookupTable *lut);

--- a/include/simcore/default_params.hpp
+++ b/include/simcore/default_params.hpp
@@ -67,7 +67,7 @@
   default_config["spherocylinder"]["diffusion_analysis"] = "false";
   default_config["spherocylinder"]["n_diffusion_samples"] = "1";
   default_config["spherocylinder"]["midstep"] = "false";
-  default_config["spindle"]["n_filaments_bud"] = "1";
+  default_config["spindle"]["n_filaments_bud"] = "0";
   default_config["spindle"]["n_filaments_mother"] = "0";
   default_config["spindle"]["alignment_potential"] = "false";
   default_config["spindle"]["k_spring"] = "1000";
@@ -91,8 +91,7 @@
   default_config["crosslink"]["force_dep_length"] = "0";
   default_config["crosslink"]["polar_affinity"] = "1";
   default_config["crosslink"]["k_spring"] = "10";
-  default_config["crosslink"]["k2_spring"] = "0";
-  default_config["crosslink"]["asymmetric_spring_flag"] = "false";
+  default_config["crosslink"]["k_spring_compress"] = "-1.";
   default_config["crosslink"]["f_stall"] = "100";
   default_config["crosslink"]["force_dep_vel_flag"] = "true";
   default_config["crosslink"]["k_align"] = "0";

--- a/include/simcore/parameters.hpp
+++ b/include/simcore/parameters.hpp
@@ -106,7 +106,7 @@ typedef species_parameters<species_id::spherocylinder> spherocylinder_parameters
 template <>
 struct species_parameters<species_id::spindle>
     : public species_base_parameters {
-  int n_filaments_bud = 1;
+  int n_filaments_bud = 0;
   int n_filaments_mother = 0;
   bool alignment_potential = false;
   double k_spring = 1000;
@@ -136,8 +136,7 @@ struct species_parameters<species_id::crosslink>
   double force_dep_length = 0;
   double polar_affinity = 1;
   double k_spring = 10;
-  double k2_spring = 0;
-  bool asymmetric_spring_flag = false;
+  double k_spring_compress = -1.;
   double f_stall = 100;
   bool force_dep_vel_flag = true;
   double k_align = 0;

--- a/include/simcore/parse_params.hpp
+++ b/include/simcore/parse_params.hpp
@@ -597,10 +597,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.polar_affinity = jt->second.as<double>();
       } else if (param_name.compare("k_spring")==0) {
       params.k_spring = jt->second.as<double>();
-      } else if (param_name.compare("k2_spring")==0) {
-      params.k2_spring = jt->second.as<double>();
-      } else if (param_name.compare("asymmetric_spring_flag")==0) {
-      params.asymmetric_spring_flag = jt->second.as<bool>();
+      } else if (param_name.compare("k_spring_compress")==0) {
+      params.k_spring_compress = jt->second.as<double>();
       } else if (param_name.compare("f_stall")==0) {
       params.f_stall = jt->second.as<double>();
       } else if (param_name.compare("force_dep_vel_flag")==0) {

--- a/src/configurator/configurator.cpp
+++ b/src/configurator/configurator.cpp
@@ -41,11 +41,9 @@ private:
 
 public:
   Configurator(std::string default_config_file)
-      : parse_params_("simcore/simulation/library/parse_params.hpp",
-                      std::ios_base::out),
-        parameters_("simcore/simulation/library/parameters.hpp",
-                    std::ios_base::out),
-        default_config_("simcore/simulation/library/default_params.hpp",
+      : parse_params_("include/simcore/parse_params.hpp", std::ios_base::out),
+        parameters_("include/simcore/parameters.hpp", std::ios_base::out),
+        default_config_("include/simcore/default_params.hpp",
                         std::ios_base::out) {
     node_ = YAML::LoadFile(default_config_file);
   }

--- a/src/crosslink.cpp
+++ b/src/crosslink.cpp
@@ -137,8 +137,8 @@ void Crosslink::DoublyKMC() {
     e_dep *= 0.5 * k_spring_compress_ * SQR(tether_stretch);
     f_dep *= k_spring_compress_ * tether_stretch;
   } else {
-    e_dep = k_spring_ * SQR(tether_stretch);
-    f_dep = k_spring_ * tether_stretch;
+    e_dep *= k_spring_ * SQR(tether_stretch);
+    f_dep *= k_spring_ * tether_stretch;
   }
   double unbind_prob = anchors_[0].GetOffRate() * delta_ * exp(e_dep + f_dep);
   double roll = rng_.RandomUniform();
@@ -251,16 +251,13 @@ void Crosslink::CalculateTetherForces() {
   Interaction ix(&anchors_[0], &anchors_[1]);
   MinimumDistance mindist;
   mindist.ObjectObject(ix);
-  /* Check stretch of tether. No penalty for having a stretch < rest_length.
-   * ie the spring does not resist compression. */
   length_ = sqrt(ix.dr_mag2);
   double stretch = length_ - rest_length_;
-  // We also update the tether's position etc, stored in the xlink position
-  // etc
   for (int i = 0; i < params_->n_dim; ++i) {
     orientation_[i] = ix.dr[i] / length_;
     position_[i] = ix.midpoint[i];
   }
+  // If compression spring constant is set, use that when spring is compressed.
   if (k_spring_compress_ >= 0 && stretch < 0)
     tether_force_ = k_spring_compress_ * stretch;
   else

--- a/src/version_generator.cpp
+++ b/src/version_generator.cpp
@@ -2,5 +2,5 @@
 /* This file should be configured by CMake to generate a cpp file that gets
    compiled to make the simcore_version variable (the most recent git commit
    sha1) available to any file that includes the above header */
-#define GIT_SHA1 "d5dd0b1dfa12be1343316b257c47c9c63075d8e2"
+#define GIT_SHA1 "56e69ecb7bcba6dea593ee4e2b8ce5445fb28c43"
 const char simcore_version[] = GIT_SHA1;


### PR DESCRIPTION
## Description of changes
Crosslinking proteins can have different spring constants depending if they are stretched or compressed. KMC module has been adapted to make sure detailed-balance is still satisfied. 

## Changes in behavior
If k_spring_compress is set to a non-negative number (zero included), crosslinks will exert different forces depending on whether they are stretched or compressed. 

Binding kinetics are also affected. A smaller k_spring_compress value will cause more binding at compressed spring configurations.

Asymmetric spring flag has been removed and default value of k_spring_compress = -1. This means that if k_spring_compress is not set, crosslinks will use k_spring for both compressed and stretched configurations. Simcore run with old parameter files should not give different results.

## Anything unresolved?
Setting k_spring_compress to non-negative number has not been fully tested. Use at your own risk. 
